### PR TITLE
Redo: GBA Graphics Editor Page

### DIFF
--- a/tools/gbage.md
+++ b/tools/gbage.md
@@ -1,0 +1,16 @@
+<p align="center">
+    <img src="res/tools/.png">
+    <h1 align="center" class="centeredHeader">Game Boy Advance Graphics Editor (GBAGE) </h1>
+    <table align="center">
+        <tr>
+            <td>Developer</td>
+            <td><a href="https://forums.serenesforest.net/index.php?/profile/104-nintenlord">Nintenlord</a></td>
+        </tr>
+        <tr>
+            <td>Latest Version (Release)</td>
+            <td><a href="https://forums.serenesforest.net/index.php?/topic/26913-nintenlords-hacking-utilities">v2.2 (August 6thth 2011)</a></td>
+        </tr>
+    </table> 
+</p>
+
+Game Boy Advance Graphics Editor is as the name implies a GBA Graphics Editor developed by Nintenlord. This program allows to view, import, and export compressed and uncompressed graphics from a GBA rom, and is also able to modify, import, and export palettes.


### PR DESCRIPTION
Redo of the GBA Graphics Editor page because Github is stupid.